### PR TITLE
ヘッダーにロゴとナビゲーションの追加

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,11 @@
+<div class="header">
+  <div class="header__logo">LOGO OKR</div>
+  <nav class="nav">
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+  </nav>
+</div>
+
 <router-outlet></router-outlet>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,12 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid #000;
+}
+
+.nav {
+  &__item {
+    padding: 8px;
+  }
+}


### PR DESCRIPTION
fix #13 

## Detail

- ヘッダーにロゴとナビゲーションの追加しました。
 
## Image
<img width="1381" alt="スクリーンショット 2020-05-30 15 17 07" src="https://user-images.githubusercontent.com/61979156/83321173-b4c0af00-a288-11ea-8348-2e59101991dc.png">
