### PR TITLE
サイドナビゲーションの作成（初期設定:表示状態）

### DIFF
--- a/src/app/manage/manage.module.ts
+++ b/src/app/manage/manage.module.ts
@@ -3,9 +3,20 @@ import { CommonModule } from '@angular/common';
 
 import { ManageRoutingModule } from './manage-routing.module';
 import { ManageComponent } from './manage/manage.component';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatListModule } from '@angular/material/list';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   declarations: [ManageComponent],
-  imports: [CommonModule, ManageRoutingModule],
+  imports: [
+    CommonModule,
+    ManageRoutingModule,
+    MatSidenavModule,
+    MatToolbarModule,
+    MatListModule,
+    MatIconModule,
+  ],
 })
 export class ManageModule {}

--- a/src/app/manage/manage/manage.component.html
+++ b/src/app/manage/manage/manage.component.html
@@ -1,1 +1,26 @@
-<p>manage works!</p>
+<mat-sidenav-container class="example-container">
+  <mat-sidenav-content>
+    <mat-toolbar class="mat-toolbar header">
+      <button mat-icon-button (click)="sidenav.toggle()">
+        <mat-icon>menu</mat-icon>
+      </button>
+      <h1>OKR APP</h1>
+    </mat-toolbar>
+  </mat-sidenav-content>
+
+  <mat-sidenav
+    #sidenav
+    fixedInViewport
+    fixedTopGap="64"
+    mode="side"
+    [opened]="opened"
+  >
+    <mat-nav-list>
+      <a mat-list-item>Example</a>
+      <a mat-list-item>ホーム</a>
+      <a mat-list-item>入力</a>
+      <a mat-list-item>利用規約</a>
+      <a mat-list-item>特定商取引法に基づく規約</a>
+    </mat-nav-list>
+  </mat-sidenav>
+</mat-sidenav-container>

--- a/src/app/manage/manage/manage.component.scss
+++ b/src/app/manage/manage/manage.component.scss
@@ -1,0 +1,26 @@
+.example-container {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+
+mat-sidenav {
+  width: 230px;
+}
+
+button {
+  margin-right: 16px;
+}
+
+.header {
+  background-color: #fff;
+  position: fixed;
+  // z-index: 1000;
+  top: 0;
+  left: 0;
+  width: 100%;
+  // min-height: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+}

--- a/src/app/manage/manage/manage.component.scss
+++ b/src/app/manage/manage/manage.component.scss
@@ -17,10 +17,8 @@ button {
 .header {
   background-color: #fff;
   position: fixed;
-  // z-index: 1000;
   top: 0;
   left: 0;
   width: 100%;
-  // min-height: 0;
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
 }

--- a/src/app/manage/manage/manage.component.ts
+++ b/src/app/manage/manage/manage.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ManageService } from './manage.service';
 
 @Component({
   selector: 'app-manage',
@@ -6,7 +7,12 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./manage.component.scss'],
 })
 export class ManageComponent implements OnInit {
-  constructor() {}
+  opened: boolean;
+
+  constructor(private manageService: ManageService) {
+    this.manageService.toggle(),
+      this.manageService.isOpen$.subscribe((opened) => (this.opened = opened));
+  }
 
   ngOnInit(): void {}
 }

--- a/src/app/manage/manage/manage.service.spec.ts
+++ b/src/app/manage/manage/manage.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ManageService } from './manage.service';
+
+describe('ManageService', () => {
+  let service: ManageService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ManageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/manage/manage/manage.service.ts
+++ b/src/app/manage/manage/manage.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Observable, ReplaySubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ManageService {
+  isOpenSource = new ReplaySubject<boolean>(1);
+  isOpen$: Observable<boolean> = this.isOpenSource.asObservable();
+  isOpened: boolean;
+
+  constructor() {}
+
+  toggle() {
+    this.isOpened = !this.isOpened; // 反転させる
+    this.isOpenSource.next(this.isOpened);
+  }
+}


### PR DESCRIPTION
fix #25 

## Detail
サイドナビゲーションが表示された状態のサイドナビゲーションを作成しました。

## Image
<img width="851" alt="スクリーンショット 2020-06-06 23 29 12" src="https://user-images.githubusercontent.com/61979156/83946872-7447cf00-a84e-11ea-869d-43bb445c3d2f.png">

## manage component htmlの実装
- [x] toolberの実装 
- [x] iconの実装 （ハンバーガーメニュー）
- [x] sidenavの実装 
- [x] navlistの実装 
## manage component scssの実装
- [x] toolberの固定 
## serviceの生成
- [x] $ ng generate service service/manage

## 分からない部分の理解
- [ ] [opened]="opened"の理解
- [ ] toggle()の呼び出しの理解

確認よろしくお願いいたします。