### PR TITLE
サービス画面の生成とヘッダーの追加

### DIFF
--- a/src/app/about/about-routing.module.ts
+++ b/src/app/about/about-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { AboutComponent } from './about/about.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: AboutComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class AboutRoutingModule {}

--- a/src/app/about/about.module.ts
+++ b/src/app/about/about.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { AboutRoutingModule } from './about-routing.module';
+import { AboutComponent } from './about/about.component';
+
+@NgModule({
+  declarations: [AboutComponent],
+  imports: [CommonModule, AboutRoutingModule],
+})
+export class AboutModule {}

--- a/src/app/about/about/about.component.html
+++ b/src/app/about/about/about.component.html
@@ -1,0 +1,10 @@
+<div class="header">
+  <div class="header__logo">LOGO OKR</div>
+  <nav class="nav">
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+    <a href="" class="nav__item">Menu</a>
+  </nav>
+</div>
+<p>about works!</p>

--- a/src/app/about/about/about.component.scss
+++ b/src/app/about/about/about.component.scss
@@ -1,0 +1,12 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px;
+  border-bottom: 1px solid #000;
+}
+
+.nav {
+  &__item {
+    padding: 8px;
+  }
+}

--- a/src/app/about/about/about.component.spec.ts
+++ b/src/app/about/about/about.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AboutComponent } from './about.component';
+
+describe('AboutComponent', () => {
+  let component: AboutComponent;
+  let fixture: ComponentFixture<AboutComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [AboutComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AboutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/about/about/about.component.ts
+++ b/src/app/about/about/about.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-about',
+  templateUrl: './about.component.html',
+  styleUrls: ['./about.component.scss'],
+})
+export class AboutComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -11,6 +11,11 @@ const routes: Routes = [
     loadChildren: () =>
       import('./manage/manage.module').then((m) => m.ManageModule),
   },
+  {
+    path: 'about',
+    loadChildren: () =>
+      import('./about/about.module').then((m) => m.AboutModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/manage/manage/manage.component.html
+++ b/src/app/manage/manage/manage.component.html
@@ -23,6 +23,7 @@
       <a mat-list-item>OKR</a>
       <a mat-list-item>Think</a>
       <a mat-list-item routerLink="/manage/edit">入力</a>
+      <a mat-list-item routerLink="/about">サービス紹介</a>
       <a mat-list-item>利用規約</a>
       <a mat-list-item>特定商取引法に基づく規約</a>
     </mat-nav-list>


### PR DESCRIPTION
fix #74 

#### サービス紹介画面を生成しました。
#### aboutページ生成
- [x] aboutモジュール生成
- [x] aboutコンポーネント生成
#### ルーティング機能追加
- [x] app routing
- [x] about routing
#### ナビゲーションの追加
- [x] about htmlにて機能追加
- [x] abou scssにて画面レイアウト
#### 画面遷移
- [x] manage htmlにて画面遷移

![about](https://user-images.githubusercontent.com/61979156/84897029-eededd00-b0df-11ea-889a-b016163c5162.gif)

ご確認よろしくお願い致します。