### PR TITLE
認証ガード実装

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,16 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { AuthGuard } from './guards/auth.guard';
 
 const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    loadChildren: () =>
+      import('./manage/manage.module').then((m) => m.ManageModule),
+    canLoad: [AuthGuard],
+    canActivate: [AuthGuard],
+  },
   {
     path: 'intl',
     loadChildren: () => import('./intl/intl.module').then((m) => m.IntlModule),
@@ -10,6 +19,8 @@ const routes: Routes = [
     path: 'manage',
     loadChildren: () =>
       import('./manage/manage.module').then((m) => m.ManageModule),
+    canLoad: [AuthGuard],
+    canActivate: [AuthGuard],
   },
   {
     path: 'about',

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(AuthGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/auth.guard.ts
+++ b/src/app/guards/auth.guard.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@angular/core';
+import {
+  CanActivate,
+  CanLoad,
+  Route,
+  UrlSegment,
+  ActivatedRouteSnapshot,
+  RouterStateSnapshot,
+  UrlTree,
+  Router,
+} from '@angular/router';
+import { Observable, from } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+import { map, take, tap } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthGuard implements CanActivate, CanLoad {
+  constructor(private authService: AuthService, private router: Router) {}
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ):
+    | Observable<boolean | UrlTree>
+    | Promise<boolean | UrlTree>
+    | boolean
+    | UrlTree {
+    return this.authService.afUser$.pipe(
+      map((user) => !!user),
+      tap((isLoggedIn) => {
+        console.log(isLoggedIn);
+        if (!isLoggedIn) {
+          this.router.navigateByUrl('/about');
+        }
+      })
+    );
+  }
+  canLoad(
+    route: Route,
+    segments: UrlSegment[]
+  ): Observable<boolean> | Promise<boolean> | boolean {
+    return this.authService.afUser$.pipe(
+      map((user) => !!user),
+      take(1),
+      tap((isLoggedIn) => {
+        if (!isLoggedIn) {
+          this.router.navigateByUrl('/about');
+        }
+      })
+    );
+  }
+}

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});


### PR DESCRIPTION
fix #78 

認証ガード機能を実装しました。

#### やりたいこと 
ログインをしていない場合にサービス（about)画面に飛ばす。

#### 作業内容
- [x] guardsの機能生成(ログインログアウト)
- [x] canLoad、canActivate処理。(authServiceのafUser$のpipe処理(もし、ログインしていない場合、サービス(about)画面に飛ばす。))
- [x] app routingにAuthGurdをimport （アクセス制御）
- [x] パスの指定がない場合にmanage画面に遷移

![ガード](https://user-images.githubusercontent.com/61979156/85262204-6cbc3300-b4a8-11ea-93a7-01616ef93993.gif)
