### PR TITLE
ログイン、ログアウト時にSnackBarでアラートを表示する。

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { MatNativeDateModule, MAT_DATE_LOCALE } from '@angular/material/core';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [AppComponent],
@@ -26,6 +27,7 @@ import { MatNativeDateModule, MAT_DATE_LOCALE } from '@angular/material/core';
     AngularFireFunctionsModule,
     AngularFireAuthModule,
     MatNativeDateModule,
+    MatSnackBarModule,
   ],
   providers: [
     { provide: REGION, useValue: 'asia-northeast1' },

--- a/src/app/manage/manage-routing.module.ts
+++ b/src/app/manage/manage-routing.module.ts
@@ -7,17 +7,17 @@ import { HomeComponent } from '../home/home/home.component';
 const routes: Routes = [
   {
     path: '',
-    component: ManageComponent,
-    children: [
-      {
-        path: 'edit',
-        component: EditComponent,
-      },
-      {
-        path: 'home',
-        component: HomeComponent,
-      },
-    ],
+    pathMatch: 'full',
+    loadChildren: () =>
+      import('./manage/manage.module').then((m) => m.ManageModule),
+  },
+  {
+    path: 'edit',
+    loadChildren: () => import('./edit/edit.module').then((m) => m.EditModule),
+  },
+  {
+    path: 'home',
+    loadChildren: () => import('./home/home.module').then((m) => m.EditModule),
   },
 ];
 

--- a/src/app/manage/manage-routing.module.ts
+++ b/src/app/manage/manage-routing.module.ts
@@ -7,20 +7,21 @@ import { HomeComponent } from '../home/home/home.component';
 const routes: Routes = [
   {
     path: '',
-    pathMatch: 'full',
-    loadChildren: () =>
-      import('./manage/manage.module').then((m) => m.ManageModule),
-  },
-  {
-    path: 'edit',
-    loadChildren: () => import('./edit/edit.module').then((m) => m.EditModule),
-  },
-  {
-    path: 'home',
-    loadChildren: () => import('./home/home.module').then((m) => m.EditModule),
+    component: ManageComponent,
+    children: [
+      {
+        path: 'edit',
+        loadChildren: () =>
+          import('../edit/edit.module').then((m) => m.EditModule),
+      },
+      {
+        path: 'home',
+        loadChildren: () =>
+          import('../home/home.module').then((m) => m.HomeModule),
+      },
+    ],
   },
 ];
-
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],

--- a/src/app/manage/manage.module.ts
+++ b/src/app/manage/manage.module.ts
@@ -7,14 +7,10 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
-import { ReactiveFormsModule, FormsModule } from '@angular/forms';
-import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { EditComponent } from '../edit/edit/edit.component';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 
 @NgModule({
-  declarations: [ManageComponent, EditComponent],
+  declarations: [ManageComponent],
   imports: [
     CommonModule,
     ManageRoutingModule,
@@ -22,11 +18,7 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
     MatToolbarModule,
     MatListModule,
     MatIconModule,
-    ReactiveFormsModule,
-    FormsModule,
-    MatInputModule,
     MatButtonModule,
-    MatDatepickerModule,
   ],
 })
 export class ManageModule {}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -3,22 +3,35 @@ import { AngularFireAuth } from '@angular/fire/auth';
 import { auth, User } from 'firebase/app';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
 })
 export class AuthService {
   afUser$: Observable<User> = this.afAuth.user;
-  constructor(private afAuth: AngularFireAuth, private router: Router) {
+  constructor(
+    private afAuth: AngularFireAuth,
+    private router: Router,
+    private snackBar: MatSnackBar
+  ) {
     this.afUser$.subscribe((user) => console.log(user));
   }
 
   login() {
-    this.afAuth.signInWithPopup(new auth.GoogleAuthProvider());
+    this.afAuth.signInWithPopup(new auth.GoogleAuthProvider()).then(() => {
+      this.snackBar.open('ログインしました', null, {
+        duration: 2000,
+      });
+    });
   }
 
   logout() {
-    this.afAuth.signOut();
-    this.router.navigateByUrl('/manage');
+    this.afAuth.signOut().then(() => {
+      this.snackBar.open('ログアウトしました', null, {
+        duration: 2000,
+      });
+    });
+    this.router.navigateByUrl('/about');
   }
 }


### PR DESCRIPTION
fix #87 

ログイン、ログアウト時にSnackBarでアラートを表示する用に実装いたしました。

- [x] MatSnackBarModuleをapp moduleにimport
- [x] MatSnackBarをauth.servise.tsにimport
- [x] ログイン、ログアウト時に.then(プロミス)で各画面にアラートの表示
- [x] manage routingの修正とedit module、manage moduleの修正を行い、整理されたディレクトリ内で処理を行えるようにする。

![ログインアラート](https://user-images.githubusercontent.com/61979156/86137483-49d4f300-bb28-11ea-8256-d8dd7c93943f.gif)
![ログアウトアラート](https://user-images.githubusercontent.com/61979156/86137485-4b062000-bb28-11ea-8482-7b4abe291969.gif)

issueではそれぞれのpath内での処理が整理されてすっきりしました。
ありがとうございました。

ご確認よろしくお願いいたします。