### PR TITLE
404ページからトップページに移動するボタンの実装と各機能の修正 

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { AngularFireAuthModule } from '@angular/fire/auth';
 import { MatNativeDateModule, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { NotFoundComponent } from './not-found/not-found.component';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [AppComponent, NotFoundComponent],
@@ -29,6 +30,7 @@ import { NotFoundComponent } from './not-found/not-found.component';
     AngularFireAuthModule,
     MatNativeDateModule,
     MatSnackBarModule,
+    MatButtonModule,
   ],
   providers: [
     { provide: REGION, useValue: 'asia-northeast1' },

--- a/src/app/edit/edit/edit.component.html
+++ b/src/app/edit/edit/edit.component.html
@@ -30,7 +30,6 @@
           required
           matInput
           [matDatepicker]="picker"
-          z
         />
         <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
         <mat-datepicker #picker></mat-datepicker>

--- a/src/app/edit/edit/edit.component.ts
+++ b/src/app/edit/edit/edit.component.ts
@@ -43,7 +43,7 @@ export class EditComponent implements OnInit {
   submit() {
     console.log(this.form.value);
     const formData = this.form.value;
-    this.okrService.createOkr({
+    this.okrService.editOkr({
       title: formData.title,
       duration: formData.duration,
       primary1: formData.primary1,

--- a/src/app/not-found/not-found.component.html
+++ b/src/app/not-found/not-found.component.html
@@ -1,4 +1,5 @@
 <div class="container">
   <h1>404</h1>
   <p>お探しのページが見つかりませんでした</p>
+  <button routerLink="/" mat-flat-button color="primary">トップへ</button>
 </div>

--- a/src/app/not-found/not-found.component.scss
+++ b/src/app/not-found/not-found.component.scss
@@ -1,7 +1,7 @@
-h1 {
+:host {
   text-align: center;
-  margin: 40px 0;
 }
-p {
-  text-align: center;
+
+h1 {
+  margin: 40px 0;
 }

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -16,7 +16,7 @@ export class OkrService {
     private router: Router
   ) {}
 
-  createOkr(okr: Okr) {
+  editOkr(okr: Okr) {
     console.log(okr);
     const id = this.db.createId();
     return this.db


### PR DESCRIPTION
fix #107  

404ページからトップページに移動するボタンの実装と各機能の修正を行いました。

- [x] 404ページからトップページに移動するボタンを実装
- [x] okr.servise,edit.component.tsの関数createOkrをeditOkrに名前を変更
- [x] edit.component.htmlのフォーマット

![404](https://user-images.githubusercontent.com/61979156/87248496-ad4e1180-c494-11ea-8bd3-4edb471a9d6f.gif)


ご確認よろしくお願い致します。