### PR TITLE
ドキュメントIDを持たせて詳細ページを作成する。

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,6 @@ import { NotFoundComponent } from './not-found/not-found.component';
 const routes: Routes = [
   {
     path: '',
-    pathMatch: 'full',
     loadChildren: () =>
       import('./manage/manage.module').then((m) => m.ManageModule),
     canLoad: [AuthGuard],

--- a/src/app/home-detail/home-detail.component.html
+++ b/src/app/home-detail/home-detail.component.html
@@ -1,0 +1,9 @@
+<mat-card *ngIf="okr">
+  <h1 class="okr__title">{{ okr.title }}</h1>
+  <h3 class="okr__duration">
+    期間:{{ okr.duration.toDate() | date: 'yyyy年MM月dd日' }}
+  </h3>
+  <p class="okr__primary1">・{{ okr.primary1 }}</p>
+  <p class="okr__primary2">・{{ okr.primary2 }}</p>
+  <p class="okr__primary3">・{{ okr.primary3 }}</p>
+</mat-card>

--- a/src/app/home-detail/home-detail.component.html
+++ b/src/app/home-detail/home-detail.component.html
@@ -1,4 +1,4 @@
-<mat-card *ngIf="okr">
+<mat-card *ngIf="okr$ | async as okr">
   <h1 class="okr__title">{{ okr.title }}</h1>
   <h3 class="okr__duration">
     期間:{{ okr.duration.toDate() | date: 'yyyy年MM月dd日' }}

--- a/src/app/home-detail/home-detail.component.spec.ts
+++ b/src/app/home-detail/home-detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomeDetailComponent } from './home-detail.component';
+
+describe('HomeDetailComponent', () => {
+  let component: HomeDetailComponent;
+  let fixture: ComponentFixture<HomeDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [HomeDetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HomeDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/home-detail/home-detail.component.ts
+++ b/src/app/home-detail/home-detail.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Okr } from '../interfaces/okr';
 import { OkrService } from '../services/okr.service';
-import { HomeComponent } from '../home/home/home.component';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-home-detail',
@@ -11,20 +11,18 @@ import { HomeComponent } from '../home/home/home.component';
   styleUrls: ['./home-detail.component.scss'],
 })
 export class HomeDetailComponent implements OnInit {
-  okrs = this.homeComponentTs.okrs$;
-  okr;
+  okr$: Observable<Okr>;
 
   constructor(
     private route: ActivatedRoute,
     private db: AngularFirestore,
-    public okrService: OkrService,
-    private homeComponentTs: HomeComponent
+    public okrService: OkrService
   ) {}
 
   ngOnInit(): void {
-    this.route.paramMap.subscribe((map) => {
-      const id = +map.get('id');
-      this.okr = this.okrs[id - 1];
+    this.route.paramMap.subscribe((params) => {
+      const id = params.get('id');
+      this.okr$ = this.okrService.getOkr(id);
     });
   }
 }

--- a/src/app/home-detail/home-detail.component.ts
+++ b/src/app/home-detail/home-detail.component.ts
@@ -4,6 +4,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Okr } from '../interfaces/okr';
 import { OkrService } from '../services/okr.service';
 import { Observable } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-home-detail',
@@ -20,9 +21,11 @@ export class HomeDetailComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.route.paramMap.subscribe((params) => {
-      const id = params.get('id');
-      this.okr$ = this.okrService.getOkr(id);
-    });
+    this.okr$ = this.route.paramMap.pipe(
+      switchMap((map) => {
+        const id = map.get('id');
+        return this.okrService.getOkr(id);
+      })
+    );
   }
 }

--- a/src/app/home-detail/home-detail.component.ts
+++ b/src/app/home-detail/home-detail.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Okr } from '../interfaces/okr';
+import { OkrService } from '../services/okr.service';
+import { HomeComponent } from '../home/home/home.component';
+
+@Component({
+  selector: 'app-home-detail',
+  templateUrl: './home-detail.component.html',
+  styleUrls: ['./home-detail.component.scss'],
+})
+export class HomeDetailComponent implements OnInit {
+  okrs = this.homeComponentTs.okrs$;
+  okr;
+
+  constructor(
+    private route: ActivatedRoute,
+    private db: AngularFirestore,
+    public okrService: OkrService,
+    private homeComponentTs: HomeComponent
+  ) {}
+
+  ngOnInit(): void {
+    this.route.paramMap.subscribe((map) => {
+      const id = +map.get('id');
+      this.okr = this.okrs[id - 1];
+    });
+  }
+}

--- a/src/app/home/home-routing.module.ts
+++ b/src/app/home/home-routing.module.ts
@@ -1,12 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { HomeComponent } from './home/home.component';
+import { HomeDetailComponent } from '../home-detail/home-detail.component';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
     component: HomeComponent,
+  },
+  {
+    path: ':id',
+    component: HomeDetailComponent,
   },
 ];
 

--- a/src/app/home/home-routing.module.ts
+++ b/src/app/home/home-routing.module.ts
@@ -6,7 +6,6 @@ import { HomeDetailComponent } from '../home-detail/home-detail.component';
 const routes: Routes = [
   {
     path: '',
-    pathMatch: 'full',
     component: HomeComponent,
   },
   {

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -5,9 +5,10 @@ import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home/home.component';
 import { OkrComponent } from './okr/okr.component';
 import { MatCardModule } from '@angular/material/card';
+import { HomeDetailComponent } from '../home-detail/home-detail.component';
 
 @NgModule({
-  declarations: [HomeComponent, OkrComponent],
+  declarations: [HomeComponent, OkrComponent, HomeDetailComponent],
   imports: [CommonModule, HomeRoutingModule, MatCardModule],
 })
 export class HomeModule {}

--- a/src/app/home/okr/okr.component.html
+++ b/src/app/home/okr/okr.component.html
@@ -1,6 +1,6 @@
 <div class="okr">
   <div class="okr__body">
-    <mat-card routerLink="/manage/home/home.id">
+    <mat-card routerLink="/manage/home/{{ okr.id }}">
       <h1 class="okr__title">{{ okr.title }}</h1>
       <h3 class="okr__duration">
         期間:{{ okr.duration.toDate() | date: 'yyyy年MM月dd日' }}

--- a/src/app/home/okr/okr.component.html
+++ b/src/app/home/okr/okr.component.html
@@ -1,6 +1,6 @@
 <div class="okr">
   <div class="okr__body">
-    <mat-card>
+    <mat-card routerLink="/manage/home/home.id">
       <h1 class="okr__title">{{ okr.title }}</h1>
       <h3 class="okr__duration">
         期間:{{ okr.duration.toDate() | date: 'yyyy年MM月dd日' }}

--- a/src/app/interfaces/okr.ts
+++ b/src/app/interfaces/okr.ts
@@ -7,4 +7,5 @@ export interface Okr {
   primary2: string;
   primary3: string;
   trainerId: string;
+  id: string;
 }

--- a/src/app/manage/manage-routing.module.ts
+++ b/src/app/manage/manage-routing.module.ts
@@ -1,8 +1,6 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { ManageComponent } from './manage/manage.component';
-import { EditComponent } from '../edit/edit/edit.component';
-import { HomeComponent } from '../home/home/home.component';
 
 const routes: Routes = [
   {

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -3,9 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Okr } from '../interfaces/okr';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
-import { map } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-
 @Injectable({
   providedIn: 'root',
 })
@@ -16,12 +14,15 @@ export class OkrService {
     private router: Router
   ) {}
 
-  editOkr(okr: Okr) {
+  editOkr(okr: Omit<Okr, 'id'>): Promise<void> {
     console.log(okr);
     const id = this.db.createId();
     return this.db
       .doc(`okrs/${id}`)
-      .set(okr)
+      .set({
+        id,
+        ...okr,
+      })
       .then(() => {
         this.snackBar.open('作成しました', null, {
           duration: 2000,
@@ -32,5 +33,10 @@ export class OkrService {
 
   getOkrs(): Observable<Okr[]> {
     return this.db.collection<Okr>(`okrs`).valueChanges();
+  }
+
+  getOkr(id: string): Observable<Okr> {
+    console.log(id);
+    return this.db.doc<Okr>(`okrs/${id}`).valueChanges();
   }
 }


### PR DESCRIPTION
fix #115

型OkrにドキュメントIDを持たせて詳細ページを作成しました。
以下作業内容になります。

- [x] 詳細ページ追加(home-detail.component)
- [x] urlからドキュメントidを取得
- [x] インターフェースにidを追加
- [x] omitで型からidを除外する
- [x] firestoreからドキュメントidを取得する。
- [x] idでパスを指定。(routerLinkで文字列の中身に変数(okr.id)を入れる)

![詳細ページ](https://user-images.githubusercontent.com/61979156/88816063-f7562780-d1f6-11ea-840e-b97b26933d22.gif)


<img width="867" alt="スクリーンショット 2020-07-29 23 50 15" src="https://user-images.githubusercontent.com/61979156/88815482-5d8e7a80-d1f6-11ea-9b2f-39bc944880d8.png">


MTGにて解説ありがとうございました。
ご確認よろしくお願いいたします。