### PR TITLE
目標詳細メニュー実装

### DIFF
--- a/src/app/home-detail/home-detail.component.html
+++ b/src/app/home-detail/home-detail.component.html
@@ -5,7 +5,78 @@
       okr.end.toDate() | date: 'yyyy年MM月dd日'
     }}
   </p>
-  <p class="okr__primary1">・{{ okr.primary1 }}</p>
-  <p class="okr__primary2">・{{ okr.primary2 }}</p>
-  <p class="okr__primary3">・{{ okr.primary3 }}</p>
+
+  <p class="okr__primary1">
+    {{ okr.primary1 }}
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="menu"
+      aria-label="Example icon-button with a menu"
+    >
+      <mat-icon class="menu">more_horiz</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item>
+        <mat-icon>open_in_full</mat-icon>
+        <span>コンテンツの詳細</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>create</mat-icon>
+        <span>テーブルに記載</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>warning</mat-icon>
+        <span>コンテンツを削除</span>
+      </button>
+    </mat-menu>
+  </p>
+
+  <p class="okr__primary2">
+    {{ okr.primary2 }}
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="menu"
+      aria-label="Example icon-button with a menu"
+    >
+      <mat-icon class="menu">more_horiz</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item>
+        <mat-icon>open_in_full</mat-icon>
+        <span>コンテンツの詳細</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>create</mat-icon>
+        <span>テーブルに記載</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>notifications_off</mat-icon>
+        <span>コンテンツを削除</span>
+      </button>
+    </mat-menu>
+  </p>
+  <p class="okr__primary3">
+    {{ okr.primary3 }}
+    <button
+      mat-icon-button
+      [matMenuTriggerFor]="menu"
+      aria-label="Example icon-button with a menu"
+    >
+      <mat-icon class="menu">more_horiz</mat-icon>
+    </button>
+    <mat-menu #menu="matMenu">
+      <button mat-menu-item>
+        <mat-icon>open_in_full</mat-icon>
+        <span>コンテンツの詳細</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>create</mat-icon>
+        <span>テーブルに記載</span>
+      </button>
+      <button mat-menu-item>
+        <mat-icon>notifications_off</mat-icon>
+        <span>コンテンツを削除</span>
+      </button>
+    </mat-menu>
+  </p>
 </mat-card>

--- a/src/app/home-detail/home-detail.component.html
+++ b/src/app/home-detail/home-detail.component.html
@@ -6,77 +6,30 @@
     }}
   </p>
 
-  <p class="okr__primary1">
-    {{ okr.primary1 }}
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      aria-label="Example icon-button with a menu"
-    >
-      <mat-icon class="menu">more_horiz</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item>
-        <mat-icon>open_in_full</mat-icon>
-        <span>コンテンツの詳細</span>
+  <div *ngFor="let list of getTimes(lists); let i = index">
+    <p class="okr__primary1">
+      {{ okr.primary[i] }}
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="menu"
+        aria-label="Example icon-button with a menu"
+      >
+        <mat-icon class="menu">more_horiz</mat-icon>
       </button>
-      <button mat-menu-item>
-        <mat-icon>create</mat-icon>
-        <span>テーブルに記載</span>
-      </button>
-      <button mat-menu-item>
-        <mat-icon>warning</mat-icon>
-        <span>コンテンツを削除</span>
-      </button>
-    </mat-menu>
-  </p>
-
-  <p class="okr__primary2">
-    {{ okr.primary2 }}
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      aria-label="Example icon-button with a menu"
-    >
-      <mat-icon class="menu">more_horiz</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item>
-        <mat-icon>open_in_full</mat-icon>
-        <span>コンテンツの詳細</span>
-      </button>
-      <button mat-menu-item>
-        <mat-icon>create</mat-icon>
-        <span>テーブルに記載</span>
-      </button>
-      <button mat-menu-item>
-        <mat-icon>notifications_off</mat-icon>
-        <span>コンテンツを削除</span>
-      </button>
-    </mat-menu>
-  </p>
-  <p class="okr__primary3">
-    {{ okr.primary3 }}
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      aria-label="Example icon-button with a menu"
-    >
-      <mat-icon class="menu">more_horiz</mat-icon>
-    </button>
-    <mat-menu #menu="matMenu">
-      <button mat-menu-item>
-        <mat-icon>open_in_full</mat-icon>
-        <span>コンテンツの詳細</span>
-      </button>
-      <button mat-menu-item>
-        <mat-icon>create</mat-icon>
-        <span>テーブルに記載</span>
-      </button>
-      <button mat-menu-item>
-        <mat-icon>notifications_off</mat-icon>
-        <span>コンテンツを削除</span>
-      </button>
-    </mat-menu>
-  </p>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item>
+          <mat-icon>open_in_full</mat-icon>
+          <span>コンテンツの詳細</span>
+        </button>
+        <button mat-menu-item routerLink="/spreadsheets/{{ okr.id }}">
+          <mat-icon>create</mat-icon>
+          <span>テーブルに記載</span>
+        </button>
+        <button mat-menu-item>
+          <mat-icon>warning</mat-icon>
+          <span>コンテンツを削除</span>
+        </button>
+      </mat-menu>
+    </p>
+  </div>
 </mat-card>

--- a/src/app/home-detail/home-detail.component.scss
+++ b/src/app/home-detail/home-detail.component.scss
@@ -1,0 +1,10 @@
+.mat-icon-button {
+  &:hover {
+    background-color: rgba(0, 0, 0, 0.12);
+  }
+}
+.menu {
+  font-size: 18px;
+  line-height: 20px;
+  opacity: 0.6;
+}

--- a/src/app/home-detail/home-detail.component.ts
+++ b/src/app/home-detail/home-detail.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { AngularFirestore } from '@angular/fire/firestore';
 import { Okr } from '../interfaces/okr';
 import { OkrService } from '../services/okr.service';
 import { Observable } from 'rxjs';
@@ -13,14 +12,15 @@ import { switchMap } from 'rxjs/operators';
 })
 export class HomeDetailComponent implements OnInit {
   okr$: Observable<Okr>;
+  lists = 5;
 
-  constructor(
-    private route: ActivatedRoute,
-    private db: AngularFirestore,
-    public okrService: OkrService
-  ) {}
+  getTimes(count: number) {
+    return [...Array(count)].map((_, i) => i + 1);
+  }
 
-  ngOnInit(): void {
+  constructor(private route: ActivatedRoute, public okrService: OkrService) {}
+
+  ngOnInit() {
     this.okr$ = this.route.paramMap.pipe(
       switchMap((map) => {
         const id = map.get('id');

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -7,6 +7,7 @@ import { MatCardModule } from '@angular/material/card';
 import { HomeDetailComponent } from '../home-detail/home-detail.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [HomeComponent, OkrComponent, HomeDetailComponent],
@@ -16,6 +17,7 @@ import { MatIconModule } from '@angular/material/icon';
     MatCardModule,
     MatButtonModule,
     MatIconModule,
+    MatMenuModule,
   ],
 })
 export class HomeModule {}


### PR DESCRIPTION
fix #54 

目標詳細メニューを実装しました。

- [x] MatMenuModuleのimport
- [x] mat-icon追加
- [x] menu実装
- [x] menuボタンレイアウト


![目標詳細メニュー](https://user-images.githubusercontent.com/61979156/90130513-8e99ae00-dda5-11ea-975d-675ad8b0b2d8.gif)

ご確認よろしくお願い致します。