### PR TITLE
UI：home.component

### DIFF
--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,11 +1,11 @@
-<div class="container">
-  <h2>OKR管理</h2>
-  <div class="grid">
-    <mat-card routerLink="/manage/edit">
-      <button>
-        <mat-icon>add</mat-icon>
+<div class="home">
+  <h2 class="home__title">OKR管理</h2>
+  <div class="home__grid">
+    <mat-card routerLink="/manage/edit" class="home__card">
+      <button class="home__button">
+        <mat-icon class="home__icon">add</mat-icon>
       </button>
-      <p>目標を追加する</p>
+      <p class="home__text">目標を追加する</p>
     </mat-card>
     <app-okr *ngFor="let okr of okrs$ | async" [okr]="okr"></app-okr>
   </div>

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -1,43 +1,44 @@
-:host {
-  display: block;
-  padding: 24px;
-}
+@import 'variables';
+@import 'mixins';
 
-.grid {
-  display: grid;
-  gap: 24px;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-}
-
-.mat-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  background-color: #fff;
-  cursor: pointer;
-  border-radius: 16px;
-  &:hover {
-    background-color: rgba(0, 0, 0, 0.12);
+.home {
+  margin: 0 auto;
+  width: 600px;
+  @include md {
+    width: 960px;
   }
-}
-
-button {
-  display: flex;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-}
-
-.mat-icon {
-  margin-bottom: 12px;
-  font-size: 36px;
-  width: 36px;
-  color: #1a73e8;
-}
-
-p {
-  font-size: 14px;
-  text-align: center;
-  color: #1a73e8;
+  &__grid {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  }
+  &__card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #fff;
+    cursor: pointer;
+    border-radius: 16px;
+    &:hover {
+      background-color: rgba(0, 0, 0, 0.12);
+    }
+  }
+  &__button {
+    display: flex;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  &__icon {
+    margin-bottom: 12px;
+    font-size: 36px;
+    width: 36px;
+    color: #1a73e8;
+  }
+  &__text {
+    font-size: 14px;
+    text-align: center;
+    color: #1a73e8;
+  }
 }

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -1,11 +1,11 @@
-@import 'variables';
 @import 'mixins';
 
 .home {
   margin: 0 auto;
-  width: 600px;
-  @include md {
-    width: 960px;
+  width: 300px;
+
+  @include sm {
+    width: 80%;
   }
   &__grid {
     display: grid;
@@ -13,6 +13,7 @@
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
   }
   &__card {
+    height: 240px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -22,6 +23,19 @@
     border-radius: 16px;
     &:hover {
       background-color: rgba(0, 0, 0, 0.12);
+    }
+    @include sm {
+      height: auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background-color: #fff;
+      cursor: pointer;
+      border-radius: 16px;
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.12);
+      }
     }
   }
   &__button {

--- a/src/app/home/okr/okr.component.html
+++ b/src/app/home/okr/okr.component.html
@@ -1,21 +1,26 @@
 <mat-card>
   <div class="card">
-    <h1 class="card__title">{{ okr.title }}</h1>
-    <div *ngFor="let primary of primaries$ | async">
-      <p>{{ primary.titles }}</p>
+    <div class="card__body">
+      <h1 class="card__title">{{ okr.title }}</h1>
+      <div *ngFor="let primary of primaries$ | async">
+        <p>{{ primary.titles }}</p>
+      </div>
+      <p class="card__duration">
+        期間: {{ okr.start.toDate() | date: 'yyyy年MM月dd日' }}〜{{
+          okr.end.toDate() | date: 'yyyy年MM月dd日'
+        }}
+      </p>
     </div>
-    <p class="card__duration">
-      期間: {{ okr.start.toDate() | date: 'yyyy年MM月dd日' }}〜{{
-        okr.end.toDate() | date: 'yyyy年MM月dd日'
-      }}
-    </p>
-    <button
-      [routerLink]="['/manage/home/homedetail']"
-      [queryParams]="{ v: okr.id }"
-      mat-raised-button
-      color="primary"
-    >
-      詳細をみる
-    </button>
+
+    <div class="card__action">
+      <button
+        [routerLink]="['/manage/home/homedetail']"
+        [queryParams]="{ v: okr.id }"
+        mat-raised-button
+        color="primary"
+      >
+        詳細をみる
+      </button>
+    </div>
   </div>
 </mat-card>

--- a/src/app/home/okr/okr.component.html
+++ b/src/app/home/okr/okr.component.html
@@ -2,25 +2,27 @@
   <div class="card">
     <div class="card__body">
       <h1 class="card__title">{{ okr.title }}</h1>
-      <div *ngFor="let primary of primaries$ | async">
-        <p>{{ primary.titles }}</p>
+      <div class="card__sub-titles">
+        <div *ngFor="let primary of primaries$ | async" class="card__sub-title">
+          <p>{{ primary.titles }}</p>
+        </div>
       </div>
       <p class="card__duration">
         期間: {{ okr.start.toDate() | date: 'yyyy年MM月dd日' }}〜{{
           okr.end.toDate() | date: 'yyyy年MM月dd日'
         }}
       </p>
-    </div>
 
-    <div class="card__action">
-      <button
-        [routerLink]="['/manage/home/homedetail']"
-        [queryParams]="{ v: okr.id }"
-        mat-raised-button
-        color="primary"
-      >
-        詳細をみる
-      </button>
+      <div class="card__action">
+        <button
+          [routerLink]="['/manage/home/homedetail']"
+          [queryParams]="{ v: okr.id }"
+          mat-raised-button
+          color="primary"
+        >
+          詳細をみる
+        </button>
+      </div>
     </div>
   </div>
 </mat-card>

--- a/src/app/home/okr/okr.component.scss
+++ b/src/app/home/okr/okr.component.scss
@@ -4,6 +4,7 @@ mat-card {
 
 .card {
   display: flex;
+  flex-wrap: wrap;
   flex-flow: column;
   &__body {
     padding: 24px;
@@ -12,6 +13,10 @@ mat-card {
   &__title {
     font-size: 20px;
     margin-bottom: 16px;
+    height: 60px;
+  }
+  &__sub-titles {
+    height: 150px;
   }
   &__duration {
     font-size: 12px;

--- a/src/app/home/okr/okr.component.scss
+++ b/src/app/home/okr/okr.component.scss
@@ -3,10 +3,21 @@ mat-card {
 }
 
 .card {
+  display: flex;
+  flex-flow: column;
+  &__body {
+    padding: 24px;
+    flex: 1;
+  }
   &__title {
     font-size: 20px;
+    margin-bottom: 16px;
   }
   &__duration {
     font-size: 12px;
+  }
+  &__action {
+    padding: 16px;
+    text-align: center;
   }
 }


### PR DESCRIPTION
fix #58 

ホーム画面のUIを調整しました。
以下作業内容です。
ご確認よろしくお願いします。

- [x] UI・余白調整
- [x] UI・要素の高さを揃える

## PC
<img width="1172" alt="スクリーンショット 2020-12-12 13 26 03" src="https://user-images.githubusercontent.com/61979156/101974493-97c85800-3c7d-11eb-9b50-6cf289107b5d.png">

## SP
<img width="392" alt="スクリーンショット 2020-12-12 13 31 59" src="https://user-images.githubusercontent.com/61979156/101975247-6c923880-3c7e-11eb-9794-b4e8426b2b4c.png">
