### PR TITLE
UI・プロフィール画像の正常表示

### DIFF
--- a/src/app/manage-header/manage-header.component.html
+++ b/src/app/manage-header/manage-header.component.html
@@ -19,15 +19,17 @@
       <mat-icon>search</mat-icon>
     </div>
 
-    <div class="header__mypage">
+    <ng-container
+      *ngIf="authService.user$ | async as user"
+      class="header__mypage"
+    >
       <button
-        mat-icon-button
-        [matMenuTriggerFor]="menu"
-        *ngIf="user$ | async as user"
-      >
-        <img [src]="avatarURL" alt="avater" class="header__avatar-image" />
-      </button>
-      <mat-menu #menu="matMenu">
+        mat-mini-fab
+        [matMenuTriggerFor]="userMenu"
+        [style.background-image]="'url(' + user?.avatarURL + ')'"
+        class="header__icon"
+      ></button>
+      <mat-menu #userMenu="matMenu">
         <button mat-menu-item *ngIf="!(user$ | async)" (click)="login()">
           <mat-icon>login</mat-icon>
           <span>ログイン</span>
@@ -41,6 +43,6 @@
           <span>開発者を応援する</span>
         </button>
       </mat-menu>
-    </div>
+    </ng-container>
   </div>
 </mat-toolbar>

--- a/src/app/manage-header/manage-header.component.scss
+++ b/src/app/manage-header/manage-header.component.scss
@@ -47,9 +47,9 @@
     grid-area: icon;
     justify-self: end;
   }
-  &__header__avatar-image {
-    border-radius: 50%;
-    width: 40px;
-    background: center/cover;
+  &__icon {
+    background-position: center;
+    background-size: cover;
+    box-shadow: none;
   }
 }

--- a/src/app/manage-header/manage-header.component.ts
+++ b/src/app/manage-header/manage-header.component.ts
@@ -13,7 +13,7 @@ export class ManageHeaderComponent implements OnInit {
 
   constructor(
     private manageService: ManageService,
-    private authService: AuthService
+    public authService: AuthService
   ) {
     this.authService.getUser(this.authService.uid).subscribe((result) => {
       this.avatarURL = result?.avatarURL;


### PR DESCRIPTION
fix #91 

お疲れ様です。
プロフィール画像が正常に表示されていなかったため、修正しました。
ご確認よろしくお願いします。

- [x] プロフィール画像の正常表示

## img
<img width="166" alt="スクリーンショット 2021-01-10 14 57 57" src="https://user-images.githubusercontent.com/61979156/104115602-3c5cb900-5354-11eb-8c31-d95a1c9208d4.png">
