### PR TITLE
退会処理実装、Firebase Hostingへのデプロイ

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": "public",
+    "public": "dist/MyApp",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,1 +1,6 @@
+import * as admin from 'firebase-admin';
+import * as functions from 'firebase-functions';
+
+admin.initializeApp(functions.config().firebase);
+
 export * from './user.function';

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -2,7 +2,6 @@ import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
 import { deleteCollectionByReference } from './utils/firebase.function';
 
-admin.initializeApp();
 const db = admin.firestore();
 
 export const createUser = functions
@@ -23,6 +22,12 @@ export const deleteUser = functions
   .auth.user()
   .onDelete((user) => {
     return db.doc(`users/${user.uid}`).delete();
+  });
+
+export const deleteAfUser = functions
+  .region('asia-northeast1')
+  .https.onCall((data: any, context: any) => {
+    return admin.auth().deleteUser(data);
   });
 
 export const deleteUserAccount = functions

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -1,5 +1,6 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
+import { deleteCollectionByReference } from './utils/firebase.function';
 
 admin.initializeApp();
 const db = admin.firestore();
@@ -22,4 +23,13 @@ export const deleteUser = functions
   .auth.user()
   .onDelete((user) => {
     return db.doc(`users/${user.uid}`).delete();
+  });
+
+export const deleteUserAccount = functions
+  .region(`asia-northeast1`)
+  .auth.user()
+  .onDelete(async (user: any, _: any) => {
+    const users = db.collection(`users`).where('uid', '==', user.uid);
+    await deleteCollectionByReference(users);
+    return;
   });

--- a/functions/src/utils/firebase.function.ts
+++ b/functions/src/utils/firebase.function.ts
@@ -1,0 +1,55 @@
+import * as admin from 'firebase-admin';
+const db = admin.firestore();
+
+export function deleteCollectionByPath(
+  collectionPath: string,
+  batchSize: number = 499
+) {
+  const collectionRef = db.collection(collectionPath);
+  const query = collectionRef.limit(batchSize);
+
+  return new Promise((resolve, reject) =>
+    deleteQueryBatch(query, batchSize, resolve, reject)
+  );
+}
+
+export function deleteCollectionByReference(
+  ref:
+    | FirebaseFirestore.Query<FirebaseFirestore.DocumentData>
+    | FirebaseFirestore.CollectionReference<FirebaseFirestore.DocumentData>,
+  batchSize: number = 499
+): Promise<void> {
+  const query = ref.limit(batchSize);
+  return new Promise((resolve, reject) =>
+    deleteQueryBatch(query, batchSize, resolve, reject)
+  );
+}
+
+function deleteQueryBatch(
+  query: FirebaseFirestore.Query<FirebaseFirestore.DocumentData>,
+  batchSize: number,
+  resolve: any,
+  reject: any
+) {
+  query
+    .get()
+    .then((snapshot) => {
+      if (snapshot.size === 0) {
+        return 0;
+      }
+
+      const batch = db.batch();
+      snapshot.docs.forEach((doc) => batch.delete(doc.ref));
+      return batch.commit().then(() => snapshot.size);
+    })
+    .then((numDeleted) => {
+      if (numDeleted === 0) {
+        resolve();
+        return;
+      }
+      process.nextTick(() =>
+        deleteQueryBatch(query, batchSize, resolve, reject)
+      );
+    })
+    .catch(reject);
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "deploy": "ng build --prod && firebase deploy --only hosting"
   },
   "husky": {
     "hooks": {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -27,6 +27,11 @@ const routes: Routes = [
       import('./about/about.module').then((m) => m.AboutModule),
   },
   {
+    path: 'settings',
+    loadChildren: () =>
+      import('./settings/settings.module').then((m) => m.SettingsModule),
+  },
+  {
     path: '**',
     component: NotFoundComponent,
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,9 +18,10 @@ import {
 } from '@angular/material/snack-bar';
 import { NotFoundComponent } from './not-found/not-found.component';
 import { MatButtonModule } from '@angular/material/button';
+import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
 
 @NgModule({
-  declarations: [AppComponent, NotFoundComponent],
+  declarations: [AppComponent, NotFoundComponent, DeleteAccountDialogComponent],
   imports: [
     BrowserModule,
     AppRoutingModule,

--- a/src/app/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.html
@@ -1,1 +1,19 @@
-<p>delete-account-dialog works!</p>
+<div class="delete-account-dialog">
+  <h2 class="delete-account-dialog__title">退会</h2>
+  <div class="delete-account-dialog__content">
+    <p>すべてのデータが削除されます。よろしいですか？</p>
+    <p>※削除されたデータはもとに戻すことはできません。</p>
+  </div>
+  <div class="delete-account-dialog__action">
+    <button
+      mat-raised-button
+      (click)="closeDeleteAccountDialog()"
+      class="delete-account-dialog__cancel"
+    >
+      キャンセル
+    </button>
+    <button color="primary" mat-raised-button (click)="deleteAccount()" s>
+      退会する
+    </button>
+  </div>
+</div>

--- a/src/app/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.html
@@ -1,0 +1,1 @@
+<p>delete-account-dialog works!</p>

--- a/src/app/delete-account-dialog/delete-account-dialog.component.scss
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.scss
@@ -1,0 +1,19 @@
+.delete-account-dialog {
+  &__content,
+  p {
+    margin: 0;
+  }
+  &__content {
+    margin-bottom: 24px;
+  }
+  &__title {
+    text-align: center;
+  }
+  &__action {
+    text-align: right;
+  }
+  &__cancel {
+    border: none;
+    background: transparent;
+  }
+}

--- a/src/app/delete-account-dialog/delete-account-dialog.component.spec.ts
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteAccountDialogComponent } from './delete-account-dialog.component';
+
+describe('DeleteAccountDialogComponent', () => {
+  let component: DeleteAccountDialogComponent;
+  let fixture: ComponentFixture<DeleteAccountDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DeleteAccountDialogComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteAccountDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { AngularFireFunctions } from '@angular/fire/functions';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 
 @Component({
   selector: 'app-delete-account-dialog',
@@ -6,7 +10,25 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./delete-account-dialog.component.scss'],
 })
 export class DeleteAccountDialogComponent implements OnInit {
-  constructor() {}
+  constructor(
+    private fns: AngularFireFunctions,
+    private authService: AuthService,
+    private router: Router,
+    private snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {}
+  deleteAccount() {
+    const callable = this.fns.httpsCallable('deleteAfUser');
+    return callable(this.authService.uid)
+      .toPromise()
+      .then(() => {
+        this.router.navigateByUrl('/');
+        this.authService.afAuth.signOut().then(() => {
+          this.snackBar.open(
+            'アカウントを削除しました。反映には時間がかかります。'
+          );
+        });
+      });
+  }
 }

--- a/src/app/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-delete-account-dialog',
+  templateUrl: './delete-account-dialog.component.html',
+  styleUrls: ['./delete-account-dialog.component.scss'],
+})
+export class DeleteAccountDialogComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AngularFireFunctions } from '@angular/fire/functions';
+import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
@@ -11,6 +12,7 @@ import { AuthService } from '../services/auth.service';
 })
 export class DeleteAccountDialogComponent implements OnInit {
   constructor(
+    private dialogRef: MatDialogRef<DeleteAccountDialogComponent>,
     private fns: AngularFireFunctions,
     private authService: AuthService,
     private router: Router,
@@ -20,6 +22,7 @@ export class DeleteAccountDialogComponent implements OnInit {
   ngOnInit(): void {}
   deleteAccount() {
     const callable = this.fns.httpsCallable('deleteAfUser');
+    this.dialogRef.close();
     return callable(this.authService.uid)
       .toPromise()
       .then(() => {
@@ -30,5 +33,9 @@ export class DeleteAccountDialogComponent implements OnInit {
           );
         });
       });
+  }
+
+  closeDeleteAccountDialog() {
+    this.dialogRef.close();
   }
 }

--- a/src/app/manage-header/manage-header.component.html
+++ b/src/app/manage-header/manage-header.component.html
@@ -42,6 +42,10 @@
           <mat-icon>support_argent</mat-icon>
           <span>開発者を応援する</span>
         </button>
+        <button mat-menu-item routerLink="/settings">
+          <mat-icon>settings</mat-icon>
+          <span>設定</span>
+        </button>
       </mat-menu>
     </ng-container>
   </div>

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -25,7 +25,7 @@ export class AuthService {
   );
 
   constructor(
-    private afAuth: AngularFireAuth,
+    public afAuth: AngularFireAuth,
     private router: Router,
     private snackBar: MatSnackBar,
     private db: AngularFirestore

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+const routes: Routes = [];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class SettingsRoutingModule {}

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,7 +1,13 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { SettingsComponent } from './settings/settings.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  {
+    path: '',
+    component: SettingsComponent,
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -3,9 +3,9 @@ import { CommonModule } from '@angular/common';
 
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsComponent } from './settings/settings.component';
-
+import { MatButtonModule } from '@angular/material/button';
 @NgModule({
   declarations: [SettingsComponent],
-  imports: [CommonModule, SettingsRoutingModule],
+  imports: [CommonModule, SettingsRoutingModule, MatButtonModule],
 })
 export class SettingsModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SettingsRoutingModule } from './settings-routing.module';
+import { SettingsComponent } from './settings/settings.component';
+
+@NgModule({
+  declarations: [SettingsComponent],
+  imports: [CommonModule, SettingsRoutingModule],
+})
+export class SettingsModule {}

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -4,8 +4,14 @@ import { CommonModule } from '@angular/common';
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsComponent } from './settings/settings.component';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule } from '@angular/material/dialog';
 @NgModule({
   declarations: [SettingsComponent],
-  imports: [CommonModule, SettingsRoutingModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    SettingsRoutingModule,
+    MatButtonModule,
+    MatDialogModule,
+  ],
 })
 export class SettingsModule {}

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -1,0 +1,1 @@
+<p>settings works!</p>

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -1,10 +1,15 @@
 <div class="settings">
-  <h1>アカウント設定</h1>
-  <h2>プロフィール</h2>
+  <h1 class="settings__title">アカウント設定</h1>
+  <h2 class="settings__profile-title">プロフィール</h2>
   <div class="settings__delete-account">
-    退会
+    <h2 class="settings__delete-title">退会</h2>
     <p>退会すると全てのデータが削除され、復元できません。</p>
-    <button color="primary" mat-raised-button (click)="deleteAccount()">
+    <button
+      color="primary"
+      mat-raised-button
+      (click)="deleteAccount()"
+      class="settings__delete-button"
+    >
       退会する
     </button>
   </div>

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -14,3 +14,12 @@
     </button>
   </div>
 </div>
+
+<footer class="footer">
+  <div class="footer__navs">
+    <a routerLink="/intl/terms">利用規約</a>
+    <a routerLink="/intl/legal">特定商取引法に基づく規約</a>
+    <a href="">サービスについて</a>
+  </div>
+  <p class="footer__copyright">©︎ okr-app</p>
+</footer>

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -1,1 +1,11 @@
-<p>settings works!</p>
+<div class="settings">
+  <h1>アカウント設定</h1>
+  <h2>プロフィール</h2>
+  <div class="settings__delete-account">
+    退会
+    <p>退会すると全てのデータが削除され、復元できません。</p>
+    <button color="primary" mat-raised-button (click)="deleteAccount()">
+      退会する
+    </button>
+  </div>
+</div>

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -7,7 +7,7 @@
     <button
       color="primary"
       mat-raised-button
-      (click)="deleteAccount()"
+      (click)="openDeleteAccountDialog()"
       class="settings__delete-button"
     >
       退会する

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -1,0 +1,17 @@
+.settings {
+  margin: 0 auto;
+  max-width: 610px;
+  &__title {
+    font-size: 24px;
+  }
+  &__profile-title {
+    font-size: 20px;
+  }
+  &__delete-title {
+    font-size: 20px;
+  }
+  &__delete-button {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+}

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -1,5 +1,5 @@
 .settings {
-  margin: 0 auto;
+  margin: 56px auto 24px;
   max-width: 610px;
   &__title {
     font-size: 24px;
@@ -13,5 +13,23 @@
   &__delete-button {
     display: block;
     margin: 0 0 0 auto;
+  }
+}
+
+.footer {
+  text-align: center;
+  padding: 24px;
+  &__navs {
+    margin-bottom: 16px;
+    color: rgba(0, 0, 0, 0.6);
+  }
+  &__copyright {
+    color: rgba(0, 0, 0, 0.38);
+    font-size: 16px;
+  }
+  a {
+    text-decoration: none;
+    margin-right: 16px;
+    color: inherit;
   }
 }

--- a/src/app/settings/settings/settings.component.spec.ts
+++ b/src/app/settings/settings/settings.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [SettingsComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss'],
+})
+export class SettingsComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { AngularFireFunctions } from '@angular/fire/functions';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { DeleteAccountDialogComponent } from 'src/app/delete-account-dialog/delete-account-dialog.component';
 import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
@@ -10,27 +12,15 @@ import { AuthService } from 'src/app/services/auth.service';
   styleUrls: ['./settings.component.scss'],
 })
 export class SettingsComponent implements OnInit {
-  constructor(
-    private fns: AngularFireFunctions,
-    private authService: AuthService,
-    private router: Router,
-    private snackBar: MatSnackBar
-  ) {}
+  constructor(private dialog: MatDialog) {}
 
   ngOnInit(): void {}
 
-  deleteAccount() {
-    const callable = this.fns.httpsCallable('deleteAfUser');
-
-    return callable(this.authService.uid)
-      .toPromise()
-      .then(() => {
-        this.router.navigateByUrl('/');
-        this.authService.afAuth.signOut().then(() => {
-          this.snackBar.open(
-            'アカウントを削除しました。反映には時間がかかります。'
-          );
-        });
-      });
+  openDeleteAccountDialog() {
+    this.dialog.open(DeleteAccountDialogComponent, {
+      width: '400px',
+      autoFocus: false,
+      restoreFocus: false,
+    });
   }
 }

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { AngularFireFunctions } from '@angular/fire/functions';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-settings',
@@ -6,7 +10,27 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./settings.component.scss'],
 })
 export class SettingsComponent implements OnInit {
-  constructor() {}
+  constructor(
+    private fns: AngularFireFunctions,
+    private authService: AuthService,
+    private router: Router,
+    private snackBar: MatSnackBar
+  ) {}
 
   ngOnInit(): void {}
+
+  deleteAccount() {
+    const callable = this.fns.httpsCallable('deleteAfUser');
+
+    return callable(this.authService.uid)
+      .toPromise()
+      .then(() => {
+        this.router.navigateByUrl('/');
+        this.authService.afAuth.signOut().then(() => {
+          this.snackBar.open(
+            'アカウントを削除しました。反映には時間がかかります。'
+          );
+        });
+      });
+  }
 }

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -18,7 +18,7 @@ export class SettingsComponent implements OnInit {
 
   openDeleteAccountDialog() {
     this.dialog.open(DeleteAccountDialogComponent, {
-      width: '400px',
+      width: '450px',
       autoFocus: false,
       restoreFocus: false,
     });

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,13 @@
 export const environment = {
-  production: true
+  production: true,
+  firebase: {
+    apiKey: 'AIzaSyDn9iFnVkalY34LDtOZN8EIfESlYVDihtA',
+    authDomain: 'okr-app-de4fa.firebaseapp.com',
+    databaseURL: 'https://okr-app-de4fa.firebaseio.com',
+    projectId: 'okr-app-de4fa',
+    storageBucket: 'okr-app-de4fa.appspot.com',
+    messagingSenderId: '104962990037',
+    appId: '1:104962990037:web:a6c1523b55ee08e88ea75c',
+    measurementId: 'G-YHBESMER0K',
+  },
 };


### PR DESCRIPTION
fix #99 

退会処理とFirebase Hostingにデプロイしました。
以下作業内容となります。
ご確認よろしくお願いします。

- [x] settings画面生成
- [x] 設定メニュー作成
- [x] UI作成
- [x] 余白調整
- [x] 退会処理実装
- [x] Firebase Hostingへのデプロイ
- [x] 退会ボタン押下時にダイアログを表示
- [x] footer作成
- [x] DeleteAccountDialogComponent作成
- [x] (DeleteAccountDialogComponent)UI作成

## GIF
![退会](https://user-images.githubusercontent.com/61979156/104152383-b52a4680-5422-11eb-80bf-cb370d1a34e9.gif)
