### PR TITLE
動作確認で出たUIと機能の修正

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,8 @@
-<main class="main">
+<mat-progress-spinner
+  class="loading"
+  mode="indeterminate"
+  *ngIf="loadingService.loading"
+></mat-progress-spinner>
+<main [class.shadow]="loadingService.loading">
   <router-outlet></router-outlet>
 </main>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,13 @@
+.loading {
+  position: absolute;
+  margin: auto;
+  z-index: 1000;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.shadow {
+  opacity: 0.4;
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,13 @@
 import { Component } from '@angular/core';
+import { LoadingService } from './services/loading.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 export class AppComponent {
   title = 'MyApp';
+
+  constructor(public loadingService: LoadingService) {}
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
 import { OkrDeleteDialogComponent } from './okr-delete-dialog/okr-delete-dialog.component';
 import { LoginDialogComponent } from './login-dialog/login-dialog.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { LoginDialogComponent } from './login-dialog/login-dialog.component';
     MatNativeDateModule,
     MatSnackBarModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
   ],
   providers: [
     { provide: REGION, useValue: 'asia-northeast1' },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,6 +22,7 @@ import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-acc
 import { OkrDeleteDialogComponent } from './okr-delete-dialog/okr-delete-dialog.component';
 import { LoginDialogComponent } from './login-dialog/login-dialog.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { CompleteOkrDialogComponent } from './complete-okr-dialog/complete-okr-dialog.component';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     DeleteAccountDialogComponent,
     OkrDeleteDialogComponent,
     LoginDialogComponent,
+    CompleteOkrDialogComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/complete-okr-dialog/complete-okr-dialog.component.html
+++ b/src/app/complete-okr-dialog/complete-okr-dialog.component.html
@@ -1,0 +1,14 @@
+<div class="complete-okr-dialog">
+  <h1 class="title">
+    進行中のダイアログを完了済みにします。
+  </h1>
+  <p class="content">完了済みにすると、達成済みから確認できます。</p>
+  <div class="actions">
+    <button mat-raised-button (click)="isCloseDialog()">
+      キャンセル
+    </button>
+    <button mat-raised-button color="primary" (click)="isCompleteDialog()">
+      完了済みにする
+    </button>
+  </div>
+</div>

--- a/src/app/complete-okr-dialog/complete-okr-dialog.component.scss
+++ b/src/app/complete-okr-dialog/complete-okr-dialog.component.scss
@@ -1,0 +1,19 @@
+.complete-okr-dialog {
+  text-align: center;
+  margin: 18px 0;
+}
+
+.title {
+  font-size: 24px;
+  margin-bottom: 30px;
+}
+
+.content {
+  font-size: 18px;
+  margin-bottom: 30px;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/app/complete-okr-dialog/complete-okr-dialog.component.spec.ts
+++ b/src/app/complete-okr-dialog/complete-okr-dialog.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompleteOkrDialogComponent } from './complete-okr-dialog.component';
+
+describe('CompleteOkrDialogComponent', () => {
+  let component: CompleteOkrDialogComponent;
+  let fixture: ComponentFixture<CompleteOkrDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [CompleteOkrDialogComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(CompleteOkrDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/complete-okr-dialog/complete-okr-dialog.component.ts
+++ b/src/app/complete-okr-dialog/complete-okr-dialog.component.ts
@@ -1,0 +1,44 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { SecondOkr } from '../interfaces/second-okr';
+import { AuthService } from '../services/auth.service';
+import { OkrService } from '../services/okr.service';
+
+@Component({
+  selector: 'app-complete-okr-dialog',
+  templateUrl: './complete-okr-dialog.component.html',
+  styleUrls: ['./complete-okr-dialog.component.scss'],
+})
+export class CompleteOkrDialogComponent implements OnInit {
+  constructor(
+    @Inject(MAT_DIALOG_DATA)
+    public data: { secondOkrId: string },
+    private okrService: OkrService,
+    private authService: AuthService,
+    private snackBar: MatSnackBar,
+    private router: Router,
+    private dialogRef: MatDialogRef<CompleteOkrDialogComponent>
+  ) {}
+
+  ngOnInit(): void {}
+
+  isCloseDialog() {
+    this.dialogRef.close();
+  }
+
+  isCompleteDialog() {
+    const secondOkrValue: SecondOkr = {
+      isComplete: false,
+    };
+    this.okrService.updateSecondOkr(
+      this.authService.uid,
+      this.data.secondOkrId,
+      secondOkrValue
+    );
+    this.dialogRef.close();
+    this.snackBar.open('お疲れ様でした✨', null);
+    this.router.navigateByUrl('manage/achieve');
+  }
+}

--- a/src/app/cv/cv.component.ts
+++ b/src/app/cv/cv.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { LoginDialogComponent } from '../login-dialog/login-dialog.component';
 import { AuthService } from '../services/auth.service';
 
 @Component({
@@ -9,16 +7,11 @@ import { AuthService } from '../services/auth.service';
   styleUrls: ['./cv.component.scss'],
 })
 export class CvComponent implements OnInit {
-  constructor(private authService: AuthService, private dialog: MatDialog) {}
+  constructor(private authService: AuthService) {}
 
   ngOnInit(): void {}
 
   login() {
-    this.authService.login().then(() => {
-      this.dialog.open(LoginDialogComponent, {
-        autoFocus: false,
-        restoreFocus: false,
-      });
-    });
+    this.authService.login();
   }
 }

--- a/src/app/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.html
@@ -12,7 +12,7 @@
     >
       キャンセル
     </button>
-    <button color="primary" mat-raised-button (click)="deleteAccount()" s>
+    <button color="primary" mat-raised-button (click)="deleteAccount()">
       退会する
     </button>
   </div>

--- a/src/app/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/delete-account-dialog/delete-account-dialog.component.ts
@@ -4,6 +4,7 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
+import { LoadingService } from '../services/loading.service';
 
 @Component({
   selector: 'app-delete-account-dialog',
@@ -16,11 +17,13 @@ export class DeleteAccountDialogComponent implements OnInit {
     private fns: AngularFireFunctions,
     private authService: AuthService,
     private router: Router,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private loadingService: LoadingService
   ) {}
 
   ngOnInit(): void {}
   deleteAccount() {
+    this.loadingService.loading = true;
     const callable = this.fns.httpsCallable('deleteAfUser');
     this.dialogRef.close();
     return callable(this.authService.uid)

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,8 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { MatDialog } from '@angular/material/dialog';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { LoginDialogComponent } from '../login-dialog/login-dialog.component';
 import { AuthService } from '../services/auth.service';
+import { LoadingService } from '../services/loading.service';
 
 @Component({
   selector: 'app-header',
@@ -12,18 +10,14 @@ import { AuthService } from '../services/auth.service';
 export class HeaderComponent implements OnInit {
   constructor(
     private authsearvice: AuthService,
-    private snackBar: MatSnackBar,
-    private dialog: MatDialog
-  ) {}
+    public loadingService: LoadingService
+  ) {
+    this.loadingService.loading = false;
+  }
 
   ngOnInit(): void {}
 
   login() {
-    this.authsearvice.login().then(() => {
-      this.dialog.open(LoginDialogComponent, {
-        autoFocus: false,
-        restoreFocus: false,
-      });
-    });
+    this.authsearvice.login();
   }
 }

--- a/src/app/hero/hero.component.ts
+++ b/src/app/hero/hero.component.ts
@@ -25,11 +25,6 @@ export class HeroComponent implements OnInit {
   }
 
   login() {
-    this.authService.login().then(() => {
-      this.dialog.open(LoginDialogComponent, {
-        autoFocus: false,
-        restoreFocus: false,
-      });
-    });
+    this.authService.login();
   }
 }

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -20,6 +20,7 @@ import { OkrEditComponent } from '../okr-edit/okr-edit.component';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { SecondOkrComponent } from '../second-okr/second-okr.component';
 import { SecondOkrTitleComponent } from '../second-okr-title/second-okr-title.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [
@@ -47,6 +48,7 @@ import { SecondOkrTitleComponent } from '../second-okr-title/second-okr-title.co
     MatDialogModule,
     MatDividerModule,
     MatDatepickerModule,
+    MatTooltipModule,
   ],
 })
 export class HomeModule {}

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -13,7 +13,11 @@
 
 <ng-template #blank>
   <div class="not-data">
-    <img src="assets/images/no-data.svg" alt="" class="not-data__img" />
+    <img
+      src="assets/images/no-data.svg"
+      alt="OKR未作成画像"
+      class="not-data__img"
+    />
     <div class="not-data__content">
       <h1 class="not-data__title">OKRが作成されていません</h1>
       <p class="not-data__text">1番目のOKRを作成しましょう!</p>

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -3,6 +3,8 @@ import { Okr } from 'src/app/interfaces/okr';
 import { OkrService } from 'src/app/services/okr.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { Observable } from 'rxjs';
+import { MatDialog } from '@angular/material/dialog';
+import { LoginDialogComponent } from 'src/app/login-dialog/login-dialog.component';
 
 @Component({
   selector: 'app-home',
@@ -15,8 +17,21 @@ export class HomeComponent implements OnInit {
 
   constructor(
     public okrService: OkrService,
-    private authService: AuthService
-  ) {}
+    private authService: AuthService,
+    private dialog: MatDialog
+  ) {
+    this.isInitLogin();
+  }
+
+  private isInitLogin() {
+    if (this.authService.isInitialLogin) {
+      this.dialog.open(LoginDialogComponent, {
+        autoFocus: false,
+        restoreFocus: false,
+      });
+      this.authService.isInitialLogin = false;
+    }
+  }
 
   ngOnInit(): void {
     this.okrs$.subscribe((okrs) => {

--- a/src/app/interfaces/second-okr-key-result.ts
+++ b/src/app/interfaces/second-okr-key-result.ts
@@ -3,7 +3,7 @@ import { firestore } from 'firebase';
 export interface SecondOkrKeyResult {
   secondOkrId: string;
   secondOkrObjectId: string;
-  id: string;
+  id?: string;
   key: string;
   target: number;
   current: number;

--- a/src/app/login-dialog/login-dialog.component.html
+++ b/src/app/login-dialog/login-dialog.component.html
@@ -2,7 +2,11 @@
   <div class="container">
     <div class="main">
       <h1 class="main__title">OKRへようこそ！</h1>
-      <img src="/assets/images/wellcome.svg" alt="" class="main__img" />
+      <img
+        src="/assets/images/wellcome.svg"
+        alt="ダイアログ画像"
+        class="main__img"
+      />
       <p class="main__content">目標に向かって頑張りましょう！</p>
     </div>
 

--- a/src/app/okr-edit/okr-edit/okr-edit.component.ts
+++ b/src/app/okr-edit/okr-edit/okr-edit.component.ts
@@ -95,7 +95,7 @@ export class OkrEditComponent implements OnInit {
     };
     const primaryArray = formData.primaries;
     this.okrService.createSecondOkr(okrValue, primaryArray).then(() => {
-      this.okrService.getSecondOkrs().subscribe((secondOkrs) => {
+      this.okrService.getSecondOkrId().subscribe((secondOkrs) => {
         secondOkrs.forEach((secondOkr) => {
           this.snackBar.open('作成しました', null);
           this.router.navigate(['manage/home/secondOkr'], {

--- a/src/app/second-okr-title/second-okr-title.component.html
+++ b/src/app/second-okr-title/second-okr-title.component.html
@@ -5,7 +5,7 @@
         secondOkr.end.toDate() | date: 'yyyy年MM月dd日'
       }}
       <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>more_horiz</mat-icon>
+        <mat-icon>keyboard_arrow_down</mat-icon>
       </button>
     </h3>
     <mat-menu #menu="matMenu">

--- a/src/app/second-okr-title/second-okr-title.component.ts
+++ b/src/app/second-okr-title/second-okr-title.component.ts
@@ -1,8 +1,10 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
+import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Observable } from 'rxjs';
+import { CompleteOkrDialogComponent } from '../complete-okr-dialog/complete-okr-dialog.component';
 import { SecondOkr } from '../interfaces/second-okr';
 import { AuthService } from '../services/auth.service';
 import { OkrService } from '../services/okr.service';
@@ -23,21 +25,17 @@ export class SecondOkrTitleComponent implements OnInit {
     public okrService: OkrService,
     public authService: AuthService,
     private router: Router,
-    private snackBar: MatSnackBar
+    private snackBar: MatSnackBar,
+    private dialog: MatDialog
   ) {}
 
   ngOnInit(): void {}
 
   secondOkrComplete() {
-    const secondOkrValue: SecondOkr = {
-      isComplete: false,
-    };
-    this.okrService.updateSecondOkr(
-      this.authService.uid,
-      this.secondOkrId,
-      secondOkrValue
-    );
-    this.snackBar.open('お疲れ様でした✨', null);
-    this.router.navigateByUrl('manage/achieve');
+    this.dialog.open(CompleteOkrDialogComponent, {
+      autoFocus: false,
+      restoreFocus: false,
+      data: { secondOkrId: this.secondOkrId },
+    });
   }
 }

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -24,10 +24,32 @@
               <table>
                 <thead>
                   <tr>
-                    <th class="header-left">項目</th>
-                    <th>標的</th>
-                    <th>現在</th>
-                    <th>パーセント</th>
+                    <th class="header-left">
+                      項目
+                      <mat-icon
+                        matTooltip="目標を達成するための項目&#13;&#10;数値的項目を入力"
+                      >
+                        help_outline
+                      </mat-icon>
+                    </th>
+                    <th>
+                      標的
+                      <mat-icon matTooltip="個数の入力">
+                        help_outline
+                      </mat-icon>
+                    </th>
+                    <th>
+                      現在
+                      <mat-icon matTooltip="達成数を入力">
+                        help_outline
+                      </mat-icon>
+                    </th>
+                    <th>
+                      パーセント
+                      <mat-icon matTooltip="自動で更新されます">
+                        help_outline
+                      </mat-icon>
+                    </th>
                     <th class="header-right">更新日</th>
                   </tr>
                 </thead>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -149,7 +149,7 @@
                         type="button"
                         (click)="removeRow(secondOkrObject.id, rowIndex)"
                       >
-                        removeRow
+                        ➖削除
                       </div>
                     </ng-container>
                   </tr>
@@ -158,7 +158,7 @@
                     (click)="addRow(secondOkrObject.id)"
                     class="second-okr__add-row"
                   >
-                    ＋addRow
+                    ➕追加
                   </div>
                 </tbody>
               </table>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -4,7 +4,7 @@
     <ng-container *ngIf="isComplete === true; else blank">
       <app-second-okr-title></app-second-okr-title>
       <div class="data">
-        <div *ngFor="let secondOkrObject of secondOkrObjects">
+        <div *ngFor="let secondOkrObject of secondOkrObjects; let i = index">
           <form [formGroup]="secondOkrObjectTitles[secondOkrObject.id]">
             <div
               *ngFor="
@@ -132,12 +132,16 @@
                       </div>
                     </ng-container>
                   </tr>
+                  <div
+                    *ngIf="rows[secondOkrObject.id].length < 3"
+                    (click)="addRow(secondOkrObject.id)"
+                    class="second-okr__add-row"
+                  >
+                    ＋addRow
+                  </div>
                 </tbody>
               </table>
             </form>
-          </div>
-          <div (click)="addRow(secondOkrObject.id)" class="second-okr__add-row">
-            ＋addRow
           </div>
           <div class="second-okr__average">
             <span class="second-okr__average-text">達成度</span

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -144,12 +144,19 @@
             </form>
           </div>
           <div class="second-okr__average">
-            <span class="second-okr__average-text">達成度</span
-            >{{
-              (secondOkrObject.average /
-                (rows[secondOkrObject.id].controls.length * 100)) *
-                100
-            }}%
+            <span class="second-okr__average-text">達成度</span>
+            <ng-container *ngIf="secondOkrObject.average === 0; else blank">
+              <span>{{ secondOkrObject.average }}%</span>
+            </ng-container>
+            <ng-template #blank>
+              <span
+                >{{
+                  (secondOkrObject.average /
+                    (rows[secondOkrObject.id].controls.length * 100)) *
+                    100
+                }}%</span
+              >
+            </ng-template>
           </div>
         </div>
       </div>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -24,11 +24,11 @@
               <table>
                 <thead>
                   <tr>
-                    <th class="header-left">key</th>
-                    <th>target</th>
-                    <th>current</th>
-                    <th>percentage</th>
-                    <th class="header-right">lastUpdate</th>
+                    <th class="header-left">項目</th>
+                    <th>標的</th>
+                    <th>現在</th>
+                    <th>パーセント</th>
+                    <th class="header-right">更新日</th>
                   </tr>
                 </thead>
 
@@ -118,7 +118,7 @@
             ＋addRow
           </div>
           <div class="second-okr__average">
-            <span class="second-okr__average-text">average</span
+            <span class="second-okr__average-text">達成度</span
             >{{
               (secondOkrObject.average /
                 (rows[secondOkrObject.id].controls.length * 100)) *

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -15,7 +15,16 @@
               class="second-okr__object"
             >
               <ng-container [formGroupName]="primaryArrayIndex">
-                <input type="text" formControlName="primaryTitle" />
+                <input
+                  (keyup)="
+                    updateSecondOkrPrimaryTitle(
+                      secondOkrObject,
+                      primaryTitle.value.primaryTitle
+                    )
+                  "
+                  type="text"
+                  formControlName="primaryTitle"
+                />
               </ng-container>
             </div>
           </form>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -187,7 +187,7 @@
       class="not-exist__img"
     />
     <div class="not-exist__content">
-      <h1 class="not-exist__title">進行中のokrがありません。</h1>
+      <h1 class="not-exist__title">進行中のOKRが作成されていません</h1>
       <p class="not-exist__text">2番目のokrを作成しましょう！</p>
     </div>
     <a

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -36,6 +36,7 @@
                     <th class="header-left">
                       項目
                       <mat-icon
+                        class="table-icon"
                         matTooltip="目標を達成するための項目&#13;&#10;数値的項目を入力"
                       >
                         help_outline
@@ -43,19 +44,25 @@
                     </th>
                     <th>
                       標的
-                      <mat-icon matTooltip="個数の入力">
+                      <mat-icon class="table-icon" matTooltip="数値を入力">
                         help_outline
                       </mat-icon>
                     </th>
                     <th>
                       現在
-                      <mat-icon matTooltip="達成数を入力">
+                      <mat-icon
+                        class="table-icon"
+                        matTooltip="達成した数値を入力"
+                      >
                         help_outline
                       </mat-icon>
                     </th>
                     <th>
                       パーセント
-                      <mat-icon matTooltip="自動で更新されます">
+                      <mat-icon
+                        class="table-icon"
+                        matTooltip="自動で更新されます"
+                      >
                         help_outline
                       </mat-icon>
                     </th>
@@ -97,10 +104,12 @@
                               rows[secondOkrObject.id].controls.length
                             )
                           "
+                          name="target"
                           type="text"
                           formControlName="target"
                           autocomplete="off"
                           required
+                          maxlength="20"
                         />
                       </td>
                       <td>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -68,7 +68,8 @@
                             updateSecondOkrKeyResult(
                               secondOkrObject.id,
                               row.value.secondOkrKeyResultId,
-                              row.value
+                              row.value,
+                              rows[secondOkrObject.id].controls.length
                             )
                           "
                           type="text"
@@ -83,7 +84,8 @@
                             updateSecondOkrKeyResult(
                               secondOkrObject.id,
                               row.value.secondOkrKeyResultId,
-                              row.value
+                              row.value,
+                              rows[secondOkrObject.id].controls.length
                             )
                           "
                           type="text"
@@ -98,7 +100,8 @@
                             updateSecondOkrKeyResult(
                               secondOkrObject.id,
                               row.value.secondOkrKeyResultId,
-                              row.value
+                              row.value,
+                              rows[secondOkrObject.id].controls.length
                             )
                           "
                           type="text"
@@ -149,13 +152,7 @@
               <span>{{ secondOkrObject.average }}%</span>
             </ng-container>
             <ng-template #blank>
-              <span
-                >{{
-                  (secondOkrObject.average /
-                    (rows[secondOkrObject.id].controls.length * 100)) *
-                    100
-                }}%</span
-              >
+              <span>{{ secondOkrObject.average }}%</span>
             </ng-template>
           </div>
         </div>

--- a/src/app/second-okr/second-okr.component.html
+++ b/src/app/second-okr/second-okr.component.html
@@ -112,7 +112,7 @@
                           type="text"
                           formControlName="percentage"
                           autocomplete="off"
-                          required
+                          disabled
                         />
                       </td>
                       <td class="body-right">
@@ -120,7 +120,7 @@
                           type="text"
                           formControlName="lastUpdated"
                           autocomplete="off"
-                          required
+                          disabled
                         />
                       </td>
                       <div

--- a/src/app/second-okr/second-okr.component.scss
+++ b/src/app/second-okr/second-okr.component.scss
@@ -53,6 +53,7 @@
   }
   &__title {
     margin: 0 0 0 0;
+    padding-bottom: 36px;
     text-align: center;
     font-size: 30px;
     @include sm {
@@ -102,7 +103,7 @@
 .not-exist {
   padding-bottom: 0;
   &__img {
-    height: 250px;
+    height: 200px;
     margin: 0 auto;
     display: block;
     @include sm {
@@ -121,6 +122,7 @@
   }
   &__title {
     text-align: center;
+    font-size: 24px;
     @include sm {
       font-size: 20px;
       font-weight: 400;

--- a/src/app/second-okr/second-okr.component.scss
+++ b/src/app/second-okr/second-okr.component.scss
@@ -28,11 +28,15 @@
     border: 1px solid rgba(0, 0, 0, 0.36);
     color: rgba(0, 0, 0, 0.36);
     font-weight: 300;
-    min-width: 250px;
+    min-width: 160px;
   }
   table {
-    min-width: 1000px;
+    width: 100%;
     border-collapse: collapse;
+    white-space: nowrap;
+    @include md {
+      max-width: 1000px;
+    }
   }
   input {
     width: 98%;

--- a/src/app/second-okr/second-okr.component.scss
+++ b/src/app/second-okr/second-okr.component.scss
@@ -86,6 +86,15 @@
   }
 }
 
+.material-icons {
+  font-size: 18px;
+}
+
+.table-icon {
+  position: absolute;
+  top: 4px;
+}
+
 .not-exist {
   padding-bottom: 0;
   &__img {

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -177,7 +177,11 @@ export class SecondOkrComponent implements OnInit {
       const secondOkrKeyResultPercentage = secondOkrKeyResults.filter(
         (secondOkrKeyResult) => {
           if (secondOkrKeyResult.secondOkrObjectId === secondOkrObjectId) {
-            return secondOkrKeyResult.percentage;
+            if (secondOkrKeyResult.percentage != 'NaN%') {
+              return secondOkrKeyResult.percentage;
+            } else {
+              return (secondOkrKeyResult.percentage = '0%');
+            }
           }
         }
       );
@@ -207,8 +211,13 @@ export class SecondOkrComponent implements OnInit {
     const target = row.target;
     const current = row.current;
     const percentage = (current / target) * 100;
-    const result = Math.round(percentage * 10) / 10;
+    let result = 0;
     const formData = row;
+    if (Math.round(percentage * 10) / 10) {
+      result = Math.round(percentage * 10) / 10;
+    } else {
+      result = 0;
+    }
     const secondOkrKeyResult: Omit<SecondOkrKeyResult, 'lastUpdated'> = {
       secondOkrId: this.secondOkrId,
       secondOkrObjectId,

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -21,10 +21,10 @@ export class SecondOkrComponent implements OnInit {
   private secondOkrId = this.route.snapshot.queryParamMap.get('v');
   row: FormGroup;
   rows: {
-    [keyName: string]: FormArray;
+    [secondOkrObjectId: string]: FormArray;
   } = {};
   secondOkrObjectTitles: {
-    [keyName: string]: FormArray;
+    [secondOkrObjectId: string]: FormArray;
   } = {};
   secondOkrObjectTitle: FormGroup;
   secondOkrObjects: SecondOkrObject[] = [];
@@ -157,6 +157,13 @@ export class SecondOkrComponent implements OnInit {
   }
 
   removeRow(secondOkrObjectId: string, rowIndex: number) {
+    const secondOkrKeyResultId = this.rows[secondOkrObjectId].value[rowIndex]
+      .secondOkrKeyResultId;
+    this.okrService.deleteSecondOkrKeyResultDocument(
+      this.secondOkrId,
+      secondOkrObjectId,
+      secondOkrKeyResultId
+    );
     this.rows[secondOkrObjectId].removeAt(rowIndex);
   }
 

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -185,7 +185,11 @@ export class SecondOkrComponent implements OnInit {
         const subTaskPercentageNumber = secondOkrKeyResultPercentage[
           i
         ].percentage.slice(0, -1);
-        average = average + +subTaskPercentageNumber;
+        if (average + +subTaskPercentageNumber) {
+          average = average + +subTaskPercentageNumber;
+        } else {
+          average = 0;
+        }
       }
       const secondOkrObject: Omit<SecondOkrObject, 'secondOkrObject'> = {
         id: secondOkrObjectId,

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -39,6 +39,7 @@ export class SecondOkrComponent implements OnInit {
   isCompletes = [];
   isSecondOkr: boolean;
   secondOkr: SecondOkr;
+  secondOkrKeyResultId: string;
 
   constructor(
     private route: ActivatedRoute,
@@ -51,7 +52,7 @@ export class SecondOkrComponent implements OnInit {
   ngOnInit() {
     combineLatest([this.secondOkrObjects$, this.secondOkrKeyResults$])
       .pipe(take(1))
-      .subscribe(([secondOkrObjects, secondOkrKeyResult]) => {
+      .subscribe(([secondOkrObjects, secondOkrKeyResults]) => {
         secondOkrObjects.forEach((secondOkrObject) => {
           this.secondOkrObjects.push(secondOkrObject);
           this.rows[secondOkrObject.id] = this.fb.array([]);
@@ -61,7 +62,7 @@ export class SecondOkrComponent implements OnInit {
             secondOkrObject.secondOkrObject
           );
         });
-        secondOkrKeyResult.forEach((secondOkrKeyResult) => {
+        secondOkrKeyResults.forEach((secondOkrKeyResult) => {
           this.initRows(
             secondOkrKeyResult.key,
             secondOkrKeyResult.target,
@@ -102,7 +103,7 @@ export class SecondOkrComponent implements OnInit {
   }
 
   initRows(
-    key: String,
+    key: string,
     target: number,
     current: number,
     percentage: string,
@@ -218,19 +219,35 @@ export class SecondOkrComponent implements OnInit {
     const secondOkrKeyResult: Omit<SecondOkrKeyResult, 'lastUpdated'> = {
       secondOkrId: this.secondOkrId,
       secondOkrObjectId,
-      id: secondOkrKeyResultId,
       key: formData.key,
       target: formData.target,
       current: formData.current,
       percentage: result + '%',
     };
-    this.okrService.updateSecondOkrKeyResult(
-      this.authService.uid,
-      this.secondOkrId,
-      secondOkrObjectId,
-      secondOkrKeyResultId,
-      secondOkrKeyResult
-    );
+    this.okrService
+      .getSecondOkrKeyResultId(this.secondOkrId)
+      .subscribe((secondOkrKeyResults) => {
+        secondOkrKeyResults.forEach((secondOkrKeyResult) => {
+          this.secondOkrKeyResultId = secondOkrKeyResult.id;
+        });
+      });
+    if (secondOkrKeyResultId) {
+      this.okrService.updateSecondOkrKeyResult(
+        this.authService.uid,
+        this.secondOkrId,
+        secondOkrObjectId,
+        secondOkrKeyResultId,
+        secondOkrKeyResult
+      );
+    } else {
+      this.okrService.updateSecondOkrKeyResult(
+        this.authService.uid,
+        this.secondOkrId,
+        secondOkrObjectId,
+        this.secondOkrKeyResultId,
+        secondOkrKeyResult
+      );
+    }
   }
 
   updateSecondOkrPrimaryTitle(

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -136,7 +136,7 @@ export class SecondOkrComponent implements OnInit {
       key: ['', [Validators.required]],
       target: ['', [Validators.required]],
       current: ['', [Validators.required]],
-      percentage: ['', [Validators.required]],
+      percentage: [0 + '%', [Validators.required]],
       lastUpdated: ['', [Validators.required]],
     });
     this.rows[secondOkrObjectId].push(this.row);

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -170,18 +170,15 @@ export class SecondOkrComponent implements OnInit {
   updateSecondOkrKeyResult(
     secondOkrObjectId: string,
     secondOkrKeyResultId: string,
-    row: SecondOkrKeyResult
+    row: SecondOkrKeyResult,
+    rowLength
   ) {
     this.secondOkrKeyResults$.subscribe((secondOkrKeyResults) => {
       let average = 0;
       const secondOkrKeyResultPercentage = secondOkrKeyResults.filter(
         (secondOkrKeyResult) => {
           if (secondOkrKeyResult.secondOkrObjectId === secondOkrObjectId) {
-            if (secondOkrKeyResult.percentage != 'NaN%') {
-              return secondOkrKeyResult.percentage;
-            } else {
-              return (secondOkrKeyResult.percentage = '0%');
-            }
+            return secondOkrKeyResult.percentage;
           }
         }
       );
@@ -197,7 +194,7 @@ export class SecondOkrComponent implements OnInit {
       }
       const secondOkrObject: Omit<SecondOkrObject, 'secondOkrObject'> = {
         id: secondOkrObjectId,
-        average: average,
+        average: Math.round((average / (rowLength * 100)) * 100),
       };
 
       this.okrService.updateSecondOkrObject(

--- a/src/app/second-okr/second-okr.component.ts
+++ b/src/app/second-okr/second-okr.component.ts
@@ -232,4 +232,16 @@ export class SecondOkrComponent implements OnInit {
       secondOkrKeyResult
     );
   }
+
+  updateSecondOkrPrimaryTitle(
+    secondOkrObject,
+    secondOkrObjects: SecondOkrObject
+  ) {
+    this.okrService.updateSecondOkrPrimaryTitle(
+      this.authService.uid,
+      this.secondOkrId,
+      secondOkrObject.id,
+      secondOkrObjects
+    );
+  }
 }

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -146,6 +146,15 @@ export class OkrService {
       .valueChanges();
   }
 
+  getSecondOkrId(): Observable<SecondOkr[]> {
+    return this.db
+      .collection<SecondOkr>(
+        `users/${this.authsearvice.uid}/secondOkrs`,
+        (ref) => ref.where('isComplete', '==', true)
+      )
+      .valueChanges();
+  }
+
   getSecondOkrObjects(id: string): Observable<SecondOkrObject[]> {
     return this.db
       .collection<SecondOkrObject>(

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -9,6 +9,7 @@ import { firestore } from 'firebase';
 import { SecondOkr } from '../interfaces/second-okr';
 import { SecondOkrKeyResult } from '../interfaces/second-okr-key-result';
 import { SecondOkrObject } from '../interfaces/second-okr-object';
+import { object } from 'firebase-functions/lib/providers/storage';
 @Injectable({
   providedIn: 'root',
 })
@@ -211,6 +212,19 @@ export class OkrService {
     return this.db
       .collectionGroup<SecondOkrKeyResult>('secondOkrKeyResults', (ref) =>
         ref.where('secondOkrId', '==', secondOkrId)
+      )
+      .valueChanges();
+  }
+
+  getSecondOkrKeyResultId(
+    secondOkrId: string
+  ): Observable<SecondOkrKeyResult[]> {
+    return this.db
+      .collectionGroup<SecondOkrKeyResult>('secondOkrKeyResults', (ref) =>
+        ref
+          .where('secondOkrId', '==', secondOkrId)
+          .orderBy('lastUpdated', 'desc')
+          .limit(1)
       )
       .valueChanges();
   }

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -280,7 +280,6 @@ export class OkrService {
     secondOkrObjectId: string,
     secondOkrObjects: SecondOkrObject
   ): Promise<void> {
-    console.log(secondOkrObjects);
     return this.db
       .doc(
         `users/${uid}/secondOkrs/${secondOkrId}/secondOkrObjects/${secondOkrObjectId}`

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -139,7 +139,10 @@ export class OkrService {
 
   getSecondOkrs(): Observable<SecondOkr[]> {
     return this.db
-      .collection<SecondOkr>(`users/${this.authsearvice.uid}/secondOkrs`)
+      .collection<SecondOkr>(
+        `users/${this.authsearvice.uid}/secondOkrs`,
+        (ref) => ref.orderBy('start', 'desc')
+      )
       .valueChanges();
   }
 

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -67,6 +67,7 @@ export class OkrService {
       })
       .then(() => {
         secondOkrObjects.forEach((secondOkrObject) => {
+          const average = 0;
           this.createSecondOkrObject(secondOkrObject, id);
         });
       });

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -202,6 +202,18 @@ export class OkrService {
       .valueChanges();
   }
 
+  deleteSecondOkrKeyResultDocument(
+    secondOkrId,
+    secondOkrObjectId,
+    secondOkrKeyResultId
+  ): Promise<void> {
+    return this.db
+      .doc<SecondOkrKeyResult>(
+        `users/${this.authsearvice.uid}/secondOkrs/${secondOkrId}/secondOkrObjects/${secondOkrObjectId}/secondOkrKeyResults/${secondOkrKeyResultId}`
+      )
+      .delete();
+  }
+
   getSecondOkrKeyResult(uid: string): Observable<SecondOkrKeyResult[]> {
     return this.db
       .collectionGroup<SecondOkrKeyResult>('secondOkrKeyResults', (ref) =>

--- a/src/app/services/okr.service.ts
+++ b/src/app/services/okr.service.ts
@@ -274,6 +274,20 @@ export class OkrService {
       .update(secondOkrObject);
   }
 
+  updateSecondOkrPrimaryTitle(
+    uid: string,
+    secondOkrId: string,
+    secondOkrObjectId: string,
+    secondOkrObjects: SecondOkrObject
+  ): Promise<void> {
+    console.log(secondOkrObjects);
+    return this.db
+      .doc(
+        `users/${uid}/secondOkrs/${secondOkrId}/secondOkrObjects/${secondOkrObjectId}`
+      )
+      .update({ secondOkrObject: secondOkrObjects });
+  }
+
   updateSubTask(
     uid: string,
     okrId: string,

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -33,64 +33,68 @@
 </div>
 
 <mat-tab-group animationDuration="0ms">
-  <mat-tab label="プロフィール">
-    <div class="settings">
-      <h1 class="settings__title">アカウント設定</h1>
-      <ng-container *ngIf="authService.user$ | async as user">
-        <h2 class="settings__profile-title">プロフィール</h2>
-        <label
-          for="avatar-file"
-          [style.background-image]="'url(' + user?.avatarURL + ')'"
-          alt="プロフィール画像"
-          class="settings__avatar-image"
-        >
-          <div class="settings__avatar-icon-wrap">
-            <mat-icon class="settings__avatar-icon">add_a_photo</mat-icon>
+  <div class="mat-tab-container">
+    <mat-tab label="プロフィール">
+      <div class="settings">
+        <div class="settings__container">
+          <h1 class="settings__title">アカウント設定</h1>
+          <ng-container *ngIf="authService.user$ | async as user">
+            <div class="settings__profile-container">
+              <h2 class="settings__profile-title">プロフィール</h2>
+              <label
+                for="avatar-file"
+                [style.background-image]="'url(' + user?.avatarURL + ')'"
+                alt="プロフィール画像"
+                class="settings__avatar-image"
+              >
+                <div class="settings__avatar-icon-wrap">
+                  <mat-icon class="settings__avatar-icon">add_a_photo</mat-icon>
+                </div>
+              </label>
+              <input
+                id="avatar-file"
+                type="file"
+                multiple
+                accept=".png, .jpg, .jpeg"
+                class="settings__avatar-input"
+                (change)="openImageCropDialog($event, imageSelecter)"
+                #imageSelecter
+              />
+            </div>
+
+            <button
+              mat-raised-button
+              (click)="openDeleteAccountDialog()"
+              class="settings__delete-button"
+            >
+              退会する
+            </button>
+          </ng-container>
+        </div>
+      </div>
+    </mat-tab>
+    <mat-tab label="開発資金をサポートする">
+      <div class="support">
+        <div class="container">
+          <h1 class="support__title">開発資金をサポートする</h1>
+          <div class="support__text">
+            <span
+              >プロダクトを使いたい、より良くしたいと思ってくれるコアな</span
+            >
+            <span>ユーザーに幾らかのご支援いただきたく思います。</span>
           </div>
-        </label>
-        <input
-          id="avatar-file"
-          type="file"
-          multiple
-          accept=".png, .jpg, .jpeg"
-          class="settings__avatar-input"
-          (change)="openImageCropDialog($event, imageSelecter)"
-          #imageSelecter
-        />
-        <div class="settings__delete-account">
-          <h2 class="settings__delete-title">退会</h2>
-          <p>退会すると全てのデータが削除され、復元できません。</p>
           <button
-            color="primary"
+            class="support__action"
+            (click)="redirectToCheckout()"
             mat-raised-button
-            (click)="openDeleteAccountDialog()"
-            class="settings__delete-button"
+            color="primary"
           >
-            退会する
+            開発資金をサポートする
           </button>
         </div>
-      </ng-container>
-    </div>
-  </mat-tab>
-  <mat-tab label="開発資金をサポートする">
-    <div class="support">
-      <div class="container">
-        <h1 class="support__title">開発資金をサポートする</h1>
-        <div class="support__text">
-          <span>プロダクトを使いたい、より良くしたいと思ってくれるコアな</span>
-          <span>ユーザーに幾らかのご支援いただきたく思います。</span>
-        </div>
-        <button
-          class="support__action"
-          (click)="redirectToCheckout()"
-          mat-raised-button
-          color="primary"
-        >
-          開発資金をサポートする
-        </button>
       </div>
-    </div>
-  </mat-tab>
+    </mat-tab>
+  </div>
 </mat-tab-group>
 
 <footer class="footer">

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -63,6 +63,10 @@
   }
 }
 
+::ng-deep .mat-tab-labels {
+  justify-content: center !important;
+}
+
 .nav {
   z-index: 1000;
   padding: 0;
@@ -120,6 +124,9 @@
 .settings {
   margin: 56px auto 24px;
   max-width: 610px;
+  &__container {
+    padding: 0 120px;
+  }
   &__title {
     font-size: 24px;
   }
@@ -131,7 +138,6 @@
   }
   &__delete-button {
     display: block;
-    margin: 0 0 0 auto;
   }
   &__avatar-image {
     position: relative;
@@ -159,6 +165,9 @@
       transition: 0.3s;
     }
   }
+  &__profile-container {
+    padding-bottom: 72px;
+  }
   &__avatar-icon {
     color: #fff;
   }
@@ -168,7 +177,7 @@
 }
 
 .container {
-  padding: 36px 0;
+  padding: 36px 120px;
 }
 
 .support {


### PR DESCRIPTION
fix #188 

お疲れ様です。
UIと機能の修正を行いました。
以下作業内容となります。

ご確認よろしくお願いします。

- [x] ログインが成功するまでローディング
- [x] 退会時のローディング
- [x] レコードタイトルを分かりやすくする
- [x] averageのNaNの修正
- [x] 削除ダイアログのUI
- [x] OKRを完了済みにするmat-icon
- [x] パーセントNanの修正
- [x] 設定画面のUI
- [x] 達成済みのOKRはcreatedAt順に表示
- [x] pacentageは入力できないようにする
- [x] secondOKR average小数点いらない
- [x] secondOKR addRow最大3つまで
- [x] removeRowで削除する
- [x] 目標更新
- [x] second-okr入力後の挙動修正
- [x]  addrowしたタイミングで入力できるようにする